### PR TITLE
use get for longName such that FX pair price can work

### DIFF
--- a/wallstreet/wallstreet.py
+++ b/wallstreet/wallstreet.py
@@ -90,7 +90,7 @@ class Stock:
         self.change = jayson['regularMarketChange']
         self.cp = jayson['regularMarketChangePercent']
         self._last_trade = datetime.utcfromtimestamp(jayson['regularMarketTime'])
-        self.name = jayson['longName']
+        self.name = jayson.get('longName', '')
         self.dy = jayson.get('trailingAnnualDividendYield', 0)
 
     def _google(self, quote, exchange=None):


### PR DESCRIPTION
Hi there - currently Yahoo API support getting currency data such as EURUSD=X as ticker 
(see https://finance.yahoo.com/quote/EURUSD%3DX/?p=EURUSD%3DX)

Unfortunately these returned JSON doesn't contain longName field, hence it failed.
Below is just a simple change to ensure it doesn't fail