### PR TITLE
Pull riskfree rates from the new Treasury XML feed

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,6 @@ license = "MIT"
 [tool.poetry.dependencies]
 python = "^3.5"
 requests = "^2.12"
-beautifulsoup4 = "^4.5"
 scipy = "^1.5"
 
 [tool.poetry.dev-dependencies]

--- a/setup.py
+++ b/setup.py
@@ -32,5 +32,5 @@ setup(
         'Programming Language :: Python :: 3.5',
     ],
     keywords='stocks options finance market shares greeks implied volatility real-time',
-    install_requires=['requests', 'beautifulsoup4', 'scipy'],
+    install_requires=['requests', 'scipy'],
 )

--- a/wallstreet/blackandscholes.py
+++ b/wallstreet/blackandscholes.py
@@ -1,5 +1,5 @@
 import requests
-from bs4 import BeautifulSoup
+import xml.etree.ElementTree as ET
 
 from scipy.interpolate import interp1d
 from scipy import sqrt, log, exp
@@ -8,36 +8,37 @@ from scipy.optimize import fsolve
 
 from wallstreet.constants import *
 
+import xml.etree.ElementTree as ET
 
 def riskfree():
     try:
         r = requests.get(TREASURY_URL)
-        soup = BeautifulSoup(r.text, 'html.parser')
 
-        table = soup.find("table", attrs={'class' : 't-chart'})
-        rows = table.find_all('tr')
-        lastrow = len(rows)-1
-        cells = rows[lastrow].find_all("td")
-        date = cells[0].get_text()
-        m1 = float(cells[1].get_text())
-        m3 = float(cells[2].get_text())
-        m6 = float(cells[3].get_text())
-        y1 = float(cells[4].get_text())
-        y2 = float(cells[5].get_text())
-        y3 = float(cells[6].get_text())
-        y5 = float(cells[7].get_text())
-        y7 = float(cells[8].get_text())
-        y10 = float(cells[9].get_text())
-        y20 = float(cells[10].get_text())
-        y30 = float(cells[11].get_text())
+        root = ET.fromstring(r.text)
+        days = root.findall('.//G_BC_CAT')
+        last = days[-1]
 
-        years = (0, 1/12, 3/12, 6/12, 12/12, 24/12, 36/12, 60/12, 84/12, 120/12, 240/12, 360/12)
-        rates = (OVERNIGHT_RATE, m1/100, m3/100, m6/100, y1/100, y2/100, y3/100, y5/100, y7/100, y10/100, y20/100, y30/100)
+        def parse(node):
+            return float(node.text)
+
+        m1 = parse(last.find('BC_1MONTH'))
+        m2 = parse(last.find('BC_2MONTH'))
+        m3 = parse(last.find('BC_3MONTH'))
+        m6 = parse(last.find('BC_6MONTH'))
+        y1 = parse(last.find('BC_1YEAR'))
+        y2 = parse(last.find('BC_2YEAR'))
+        y3 = parse(last.find('BC_3YEAR'))
+        y5 = parse(last.find('BC_5YEAR'))
+        y7 = parse(last.find('BC_7YEAR'))
+        y10 = parse(last.find('BC_10YEAR'))
+        y20 = parse(last.find('BC_20YEAR'))
+        y30 = parse(last.find('BC_30YEAR'))
+
+        years = (0, 1/12, 2/12, 3/12, 6/12, 12/12, 24/12, 36/12, 60/12, 84/12, 120/12, 240/12, 360/12)
+        rates = (OVERNIGHT_RATE, m1/100, m2/100, m3/100, m6/100, y1/100, y2/100, y3/100, y5/100, y7/100, y10/100, y20/100, y30/100)
         return interp1d(years, rates)
-    # If scraping treasury data fails use the constant fallback risk free rate
     except Exception:
         return lambda x: FALLBACK_RISK_FREE_RATE
-
 
 class BlackandScholes:
 

--- a/wallstreet/constants.py
+++ b/wallstreet/constants.py
@@ -2,8 +2,7 @@
 DATE_FORMAT = '%d-%m-%Y'
 DATETIME_FORMAT = '%e %b %Y %H:%M:%S'
 
-TREASURY_URL = "http://www.treasury.gov/resource-center/data-chart-center/interest-rates/Pages/TextView.aspx?data=yield"
-
+TREASURY_URL = "https://home.treasury.gov/sites/default/files/interest-rates/yield.xml"
 DELTA_DIFFERENTIAL = 1.e-3
 VEGA_DIFFERENTIAL = 1.e-4
 GAMMA_DIFFERENTIAL = 1.e-3


### PR DESCRIPTION
The place where we used to pull rates is gone, there are a bunch of XML feeds in the treasury site https://home.treasury.gov/developer-notice-xml-changes

I used the `Daily Treasury Par Yield Curve Rates` at
[​https://home.treasury.gov/sites/default/files/interest-rates/yield.xml](https://edit.treasury.gov/sites/default/files/interest-rates/yield.xml)